### PR TITLE
BUG solve: callback function was global, now is one by one

### DIFF
--- a/emoji.js
+++ b/emoji.js
@@ -50,7 +50,7 @@
       return;
     }
 
-    configuration = $.extend(emojiConfiguration, options);
+    configuration = $.extend({}, emojiConfiguration, options);
     configuration.event = configuration.event.toLowerCase();
 
     if(configuration.emojis.length == 0 && configuration.debug){


### PR DESCRIPTION
When i tried to use different callbacks to different ratings in the same page, i found the error who lib use just the last callback for every instance of emoji in the page... that error is just because you put all the contents of options received into the emojiConfiguration array.